### PR TITLE
fix: getSimpleName is not working for anonymous classes

### DIFF
--- a/emt4j-common/src/main/java/org/eclipse/emt4j/common/classanalyze/AsmClassMethodsAccessor.java
+++ b/emt4j-common/src/main/java/org/eclipse/emt4j/common/classanalyze/AsmClassMethodsAccessor.java
@@ -45,7 +45,10 @@ public class AsmClassMethodsAccessor implements ClassMethodsAccessor {
     }
 
     private void readClass(Class targetClass, Consumer<byte[]> consumer) {
-        try (InputStream in = targetClass.getResourceAsStream(targetClass.getSimpleName() + ".class")) {
+        String name = targetClass.getName();
+        // also works well for non-package classes
+        name = name.substring(name.lastIndexOf(".") + 1);
+        try (InputStream in = targetClass.getResourceAsStream(name + ".class")) {
             if (in != null) {
                 ByteArrayOutputStream bos = new ByteArrayOutputStream(4096);
                 byte[] buffer = new byte[4096];


### PR DESCRIPTION
According to the current implementation, `getSimpleName` cannot return the expected name for anonymous classes. For instance, "B" will be returned for class "A$B". Hence, it failed to read class content by `getResourceAsStream`.