### PR TITLE
Call external tools as services

### DIFF
--- a/emt4j-analysis/src/main/java/org/eclipse/emt4j/analysis/AnalysisMain.java
+++ b/emt4j-analysis/src/main/java/org/eclipse/emt4j/analysis/AnalysisMain.java
@@ -74,6 +74,8 @@ public class AnalysisMain {
             checkConfig.setVerbose(true);
             reportConfig.setVerbose(true);
         }));
+        optionProcessor.addOption(Option.buildParamWithValueOption("-e", (v) -> new File(v).exists()
+                && new File(v).isDirectory(), (v) -> reportConfig.setExternalToolRoot(v)));
         optionProcessor.addOption(Option.buildDefaultOption((v) -> getSource(v).isPresent(),
                 (v) -> {
                     DependencySource ds = getSource(v).get();
@@ -142,12 +144,13 @@ public class AnalysisMain {
         String osName = System.getProperty("os.name");
         boolean windows = osName != null && osName.toLowerCase().indexOf("windows") != -1;
         String launcher = windows ? "analysis.bat" : "analysis.sh";
-        System.err.println("Usage:" + launcher + " [-f version] [-t version] [-p txt] [-o outputfile] [-j target jdk home] [-v] <files>");
+        System.err.println("Usage:" + launcher + " [-f version] [-t version] [-p txt] [-o outputfile] [-j target jdk home] [-e external tool home] [-v] <files>");
         System.err.println("-f From which JDK version,default is 8");
         System.err.println("-t To which JDK version,default is 11");
         System.err.println("-p The report format.Can be TXT or JSON or HTML.Default is HTML");
         System.err.println("-o Write analysis to output file. Default is " + DEFAULT_FILE);
-        System.err.println("-j target jdk home.Provide target jdk home can help to find more compatible problems.");
+        System.err.println("-j Target JDK home. Provide target jdk home can help to find more compatible problems.");
+        System.err.println("-e The root directory of external tools.");
         System.err.println("-v Show verbose information.");
         System.err.println("files can be combination of following types :");
         final String[] allSupportFiles = new String[]{

--- a/emt4j-analysis/src/main/java/org/eclipse/emt4j/analysis/api/JdkCompatibleCheckFacade.java
+++ b/emt4j-analysis/src/main/java/org/eclipse/emt4j/analysis/api/JdkCompatibleCheckFacade.java
@@ -66,6 +66,7 @@ public final class JdkCompatibleCheckFacade {
         reportConfig.setLocale(request.getReportLocale());
         reportConfig.setTargetJdkHome(request.getTargetJdkHome());
         reportConfig.setVerbose(request.isVerbose());
+        reportConfig.setExternalToolRoot(request.getExternalToolHome());
         ReportExecutor reportExecutor = new ReportExecutor(reportConfig);
         reportExecutor.execute(outputConsumer.getInputProvider(), progress);
 

--- a/emt4j-analysis/src/main/java/org/eclipse/emt4j/analysis/common/util/ProcessUtil.java
+++ b/emt4j-analysis/src/main/java/org/eclipse/emt4j/analysis/common/util/ProcessUtil.java
@@ -19,6 +19,7 @@
 package org.eclipse.emt4j.analysis.common.util;
 
 import java.io.*;
+import java.util.List;
 
 public class ProcessUtil {
     public static String run(String... commands) throws IOException {
@@ -38,5 +39,20 @@ public class ProcessUtil {
             sb.append(s).append('\n');
         }
         return sb.toString();
+    }
+
+    /**
+     * To avoid process blocking due to too many console output
+     * @param commands
+     * @return
+     * @throws IOException
+     * @throws InterruptedException
+     */
+    public static int noBlockingRun(List<String> commands) throws IOException, InterruptedException {
+        ProcessBuilder pb = new ProcessBuilder();
+        pb.command(commands);
+        pb.redirectOutput(ProcessBuilder.Redirect.INHERIT);
+        pb.redirectError(ProcessBuilder.Redirect.INHERIT);
+        return pb.start().waitFor();
     }
 }

--- a/emt4j-analysis/src/main/java/org/eclipse/emt4j/analysis/report/ReportExecutor.java
+++ b/emt4j-analysis/src/main/java/org/eclipse/emt4j/analysis/report/ReportExecutor.java
@@ -22,7 +22,14 @@ import org.eclipse.emt4j.analysis.common.ReportInputProvider;
 import org.eclipse.emt4j.analysis.common.model.ExternalToolParam;
 import org.eclipse.emt4j.analysis.common.util.JdkUtil;
 import org.eclipse.emt4j.analysis.common.util.Progress;
-import org.eclipse.emt4j.analysis.report.render.*;
+import org.eclipse.emt4j.analysis.report.external.ExternalToolFailException;
+import org.eclipse.emt4j.analysis.report.external.ModifyReportTool;
+import org.eclipse.emt4j.analysis.report.external.Tool;
+import org.eclipse.emt4j.analysis.report.render.ApiRender;
+import org.eclipse.emt4j.analysis.report.render.HtmlRender;
+import org.eclipse.emt4j.analysis.report.render.JsonRender;
+import org.eclipse.emt4j.analysis.report.render.Render;
+import org.eclipse.emt4j.analysis.report.render.TxtRender;
 import org.eclipse.emt4j.common.CheckResultContext;
 import org.eclipse.emt4j.common.DependType;
 import org.eclipse.emt4j.common.ReportConfig;
@@ -32,9 +39,20 @@ import org.eclipse.emt4j.common.util.ClassURL;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.*;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.Set;
 
 /**
  * Do the real report work.
@@ -58,15 +76,63 @@ public class ReportExecutor {
         new Progress(parentProgress, "Read dependency records").printTitle();
         List<BodyRecord> recordList = reportInputProvider.getRecords();
 
-        //If there are too many jars(>3000), run external tools take a long time
-        //We implement a mini version but enough to use.so comment following code.
-        /*log("Prepare for invoking external tools.");
+        log("Prepare for invoking external tools.");
         new Progress(parentProgress, "Prepare for external tools").printTitle();
         ExternalToolParam etp = prepareExternalToolParam(recordList, reportInputProvider.getHeader());
-        Progress runExternalProgress = new Progress(parentProgress, "Run external tools");
-        runExternalProgress.printTitle();
-        recordList.addAll(decorateWithExternalTools(etp, runExternalProgress));*/
+        String externalToolRoot = reportConfig.getExternalToolRoot();
+        if (externalToolRoot != null) {
+            Path root = Paths.get(externalToolRoot);
+            // Each directory in external tool root is the home of one external tool
+            List<URL> urls = new ArrayList<>();
+            try {
+                Files.list(root).filter(p -> Files.isDirectory(p)).forEach(p -> {
+                    // Add jar files in each external tool' directory to URL list.
+                    try {
+                        Files.list(p).filter(f -> f.getFileName().toString().endsWith(".jar")).forEach(f -> {
+                            try {
+                                urls.add(f.toUri().toURL());
+                            } catch (MalformedURLException e) {
+                                log(e);
+                            }
+                        });
+                    } catch (IOException e) {
+                        log(e);
+                    }
+                });
+            } catch (IOException e) {
+                log(e);
+            }
+            if (!urls.isEmpty()) {
+                URLClassLoader externalToolLoader = new URLClassLoader(urls.toArray(new URL[0]), this.getClass().getClassLoader());
+                Iterator<Tool> toolIterator = ServiceLoader.load(Tool.class, externalToolLoader).iterator();
+                List<Tool> externalTools = new ArrayList<>();
+                while (toolIterator.hasNext()) {
+                    externalTools.add(toolIterator.next());
+                }
+                int externalToolSize = externalTools.size();
+                if (externalToolSize > 0) {
+                    Progress runExternalProgress = new Progress(parentProgress, "There are " + externalToolSize + " external tools to run");
+                    runExternalProgress.printTitle();
+                    for (int i = 0; i < externalToolSize; i++) {
+                        Tool tool = externalTools.get(i);
+                        new Progress(parentProgress, "Run " + (i + 1) + "/" + externalToolSize + " external tool:" + tool.name()).printTitle();
 
+                        if (tool instanceof ModifyReportTool) {
+                            // ModifyReportTool can delete the existing records and add new ones.
+                            try {
+                                recordList = ((ModifyReportTool) tool).run(recordList, etp, reportConfig, parentProgress);
+                            } catch (ExternalToolFailException e) {
+                                new Progress(parentProgress, "Fail to run external tool:" + tool.name()).printTitle();
+                                e.printStackTrace();
+                            }
+                        } else {
+                            // Other Tools only add new records.
+                            recordList.addAll(tool.analysis(etp, reportConfig, parentProgress));
+                        }
+                    }
+                }
+            }
+        }
         this.render = createRender();
         new Progress(parentProgress, "Write result to report file").printTitle();
         render.doRender(prepare(recordList));
@@ -155,6 +221,12 @@ public class ReportExecutor {
     private void log(String msg) {
         if (reportConfig.isVerbose()) {
             System.out.println(msg);
+        }
+    }
+
+    private void log(Exception e) {
+        if (reportConfig.isVerbose()) {
+            e.printStackTrace();
         }
     }
 }

--- a/emt4j-analysis/src/main/java/org/eclipse/emt4j/analysis/report/external/ExternalToolFailException.java
+++ b/emt4j-analysis/src/main/java/org/eclipse/emt4j/analysis/report/external/ExternalToolFailException.java
@@ -16,20 +16,19 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
-package org.eclipse.emt4j.analysis.common.model;
+package org.eclipse.emt4j.analysis.report.external;
 
-import lombok.Data;
+public class ExternalToolFailException extends RuntimeException{
 
-import java.util.List;
-import java.util.Locale;
+    public ExternalToolFailException(Throwable cause) {
+        super(cause);
+    }
 
-@Data
-public class JdkCheckCompatibleRequest {
-    private int fromVersion;
-    private int toVersion;
-    private Locale reportLocale;
-    private List<ToCheckTarget> toCheckTargetList;
-    private String targetJdkHome;
-    private boolean verbose;
-    private String externalToolHome;
+    public ExternalToolFailException(String msg){
+        super(msg);
+    }
+
+    public ExternalToolFailException(String msg, Throwable cause){
+        super(msg, cause);
+    }
 }

--- a/emt4j-analysis/src/main/java/org/eclipse/emt4j/analysis/report/external/ModifyReportTool.java
+++ b/emt4j-analysis/src/main/java/org/eclipse/emt4j/analysis/report/external/ModifyReportTool.java
@@ -1,0 +1,172 @@
+/********************************************************************************
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+package org.eclipse.emt4j.analysis.report.external;
+
+import org.eclipse.emt4j.analysis.common.model.ExternalToolParam;
+import org.eclipse.emt4j.analysis.common.util.ProcessUtil;
+import org.eclipse.emt4j.analysis.common.util.Progress;
+import org.eclipse.emt4j.common.ReportConfig;
+import org.eclipse.emt4j.common.fileformat.BodyRecord;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * For the external tools that may modify(delete and add) the EMT4J output report based on the its analysis results.
+ * The tool's dependencies should be specified in the resource file externaltool/full.qualified.tool.class.name. Each line
+ * of the resource file is one maven dependency, in the form of {@code [groupid]:[artifactid]:[version](:[classifier])}.
+ */
+public abstract class ModifyReportTool implements Tool {
+
+    protected int leastJDKVersion;  // The least JDK version required to run the external tool
+    /**
+     * The class path for the external tool, should be prepared by {@link ModifyReportTool#resolveDependencies()}
+     */
+    protected String toolCP;
+
+    /**
+     * Execute the external tool with the given BodyRecord list and other parameters. The input BodyRecord list shall be
+     * modified(both deletion and adding), and a new list will be returned.
+     *
+     * @param originalReport
+     * @param etp
+     * @param reportConfig
+     * @param parentProgress
+     * @return
+     * @throws ExternalToolFailException fail to execute the external tool.
+     */
+    public List<BodyRecord> run(List<BodyRecord> originalReport, ExternalToolParam etp, ReportConfig reportConfig, Progress parentProgress) throws ExternalToolFailException {
+        try {
+            initWithOriginalReport(originalReport);
+            resolveDependencies();
+            return analysis(etp, reportConfig, parentProgress);
+        } catch (Throwable t) {
+            ExternalToolFailException e;
+            if (t instanceof ExternalToolFailException) {
+                e = (ExternalToolFailException) t;
+            } else {
+                e = new ExternalToolFailException(t);
+            }
+            throw e;
+        }
+    }
+
+    /**
+     * By default, put everything in tool's lib directory to cp.
+     */
+    protected void resolveDependencies() {
+        URL location = this.getClass().getProtectionDomain().getCodeSource().getLocation();
+        try {
+            Path jarPath = Paths.get(location.toURI());
+            Path lib = jarPath.getParent().resolve("lib");
+            if(Files.exists(lib)){
+                toolCP = Files.list(lib).filter(p->p.getFileName().toString().endsWith(".jar")).map(p->p.normalize().toAbsolutePath().toString()).collect(Collectors.joining(File.pathSeparator));
+            }
+        } catch (URISyntaxException|IOException e) {
+            throw new ExternalToolFailException(e);
+        }
+    }
+
+    protected abstract void initWithOriginalReport(List<BodyRecord> originalReport);
+
+    /**
+     * The external tool may depend on a particular JDK version set by {@link ModifyReportTool#leastJDKVersion}.
+     * Look for the proper JDK for external tool from 4 places:
+     * <ol>
+     *     <li>Currently executing java home. Usually 8.</li>
+     *     <li>-j option. 11 or 17</li>
+     *     <li>System variable $JAVA_HOME</li>
+     *     <li>java in system path</li>
+     * </ol>
+     *
+     * @param reportConfig
+     * @return
+     */
+    protected Path lookForProperJavaHome(ReportConfig reportConfig) throws IOException {
+        // 1.Check current running java version first. It should be JDK 8.
+        String javaVersion = System.getProperty("java.version");
+        int currentJavaVersion = extractJavaVersionFromString(javaVersion, 0);
+        if (currentJavaVersion >= leastJDKVersion) {
+            return appendJava(Paths.get(System.getProperty("java.home")));
+        }
+
+        // 2.Check JDK home set by -j option. It's JDK 11 or 17.
+        if (reportConfig.getTargetJdkHome() != null) {
+            return appendJava(Paths.get(reportConfig.getTargetJdkHome()));
+        }
+
+        // 3. -j not set, check Java on current machine by looking up system variables
+        Path systemJavaHome = Paths.get(System.getenv("JAVA_HOME"));
+        Path systemJava = appendJava(systemJavaHome);
+        int systemJavaVersion = checkJDKVersion(systemJava);
+        if (systemJavaVersion >= leastJDKVersion) {
+            return systemJava;
+        }
+
+        // 4. Check java on system $PATH
+        String[] paths = System.getenv("PATH").split(File.pathSeparator);
+        for (String path : paths) {
+            Path javaPath = Paths.get(path).resolve("java");
+            if (Files.exists(javaPath)) {
+                int systemPathJavaVersion = checkJDKVersion(javaPath);
+                if (systemPathJavaVersion >= leastJDKVersion) {
+                    return javaPath;
+                }
+                break;
+            }
+        }
+
+        // 5. Throw exception if non of above JDK is found as proper
+        throw new RuntimeException(this.getClass().getSimpleName() + " requires at least JDK " + leastJDKVersion + " to run." +
+                "This problem can be fixed in 4 ways: 1) Start EMT4J with the required JDK; " +
+                "2) Set EMT4J -j option to the required JDK; 3) Set your system variable JAVA_HOME to the required JDK;" +
+                "4) Set required JDK bin to the system variable PATH.");
+
+    }
+
+    private static Path appendJava(Path jdkHome) {
+        return jdkHome.resolve("bin").resolve("java");
+    }
+
+    private int checkJDKVersion(Path java) throws IOException {
+        String output = ProcessUtil.run(java.toString(), "-version");
+        // run `java -version` will output the version enclosed in a pair of quotes("").
+        return extractJavaVersionFromString(output, output.indexOf("\"") + 1);
+    }
+
+    private int extractJavaVersionFromString(String str, int startIndex) {
+        if (str.contains("1.8")) {
+            return 8;
+        } else {
+            String versionStr = str.substring(startIndex, startIndex + 2);
+            try {
+                return Integer.parseInt(versionStr);
+            } catch (NumberFormatException e) {
+                return -1;
+            }
+        }
+    }
+}

--- a/emt4j-analysis/src/test/java/org/eclipse/emt4j/analysis/api/TestJdkCompatibleCheckFacade.java
+++ b/emt4j-analysis/src/test/java/org/eclipse/emt4j/analysis/api/TestJdkCompatibleCheckFacade.java
@@ -43,6 +43,7 @@ public class TestJdkCompatibleCheckFacade {
         request.setFromVersion(8);
         request.setToVersion(11);
         request.setReportLocale(Locale.CHINA);
+        request.setExternalToolHome(System.getProperty("user.home") + "/emt4j-external");
         List<ToCheckTarget> toCheckTargetList = new ArrayList<>();
         ToCheckTarget toCheckTarget = new ToCheckTarget();
         toCheckTarget.setTargetType(CheckTargetTypeEnum.JAR);

--- a/emt4j-common/src/main/java/org/eclipse/emt4j/common/ReportConfig.java
+++ b/emt4j-common/src/main/java/org/eclipse/emt4j/common/ReportConfig.java
@@ -35,6 +35,16 @@ public class ReportConfig {
 
     private String targetJdkHome;
 
+    public String getExternalToolRoot() {
+        return externalToolRoot;
+    }
+
+    public void setExternalToolRoot(String externalToolRoot) {
+        this.externalToolRoot = externalToolRoot;
+    }
+
+    private String externalToolRoot;
+
     public List<File> getInputFiles() {
         return inputFiles;
     }

--- a/emt4j-common/src/main/resources/default/i18n/SYSTEM_CLASSLOADER_TO_URLCLASSLOADER.properties
+++ b/emt4j-common/src/main/resources/default/i18n/SYSTEM_CLASSLOADER_TO_URLCLASSLOADER.properties
@@ -15,6 +15,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 title=Throw exception when cast system classloader to URLClassLoader
-description=In JDK 8 , system classloader is a subclass of URLClassLoader, but this is not true in JDK 11. Actually it changes to an internal classloader in JDK 11.\
-  If cast system classloader to URLClassLoader will occur class cast exception.
-solution=Do not depend on the system classloader's type,it's JDK internal implementation.
+description=In JDK 8 , system classloader is a subclass of URLClassLoader, but this is not true in JDK 11. \
+  Casting system classloader to URLClassLoader will cause class cast exception.
+solution=Do not depend on the system classloader's type, it's JDK internal implementation.

--- a/emt4j-plugin/src/main/java/org/eclipse/emt4j/plugin/JdkIncompatibleCheckMojo.java
+++ b/emt4j-plugin/src/main/java/org/eclipse/emt4j/plugin/JdkIncompatibleCheckMojo.java
@@ -83,6 +83,9 @@ public class JdkIncompatibleCheckMojo extends AbstractMojo {
     @Parameter
     private String outputFile;
 
+    @Parameter
+    private String externalToolHome;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         MavenProject project = (MavenProject) getPluginContext().get("project");
@@ -126,6 +129,7 @@ public class JdkIncompatibleCheckMojo extends AbstractMojo {
         this.outputFile = selectValue(this.outputFile, "outputFile");
         this.projectBuildDir = selectValue(this.projectBuildDir, "projectBuildDir");
         this.outputFormat = selectValue(this.outputFormat, "outputFormat");
+        this.externalToolHome = selectValue(this.externalToolHome, "externalToolHome");
     }
 
     private int selectValue(int value, String propertyKey) {
@@ -148,6 +152,7 @@ public class JdkIncompatibleCheckMojo extends AbstractMojo {
         param(args, "-t", String.valueOf(toVersion));
         param(args, "-p", format);
         param(args, "-o", output.getAbsolutePath());
+        param(args, "-e", externalToolHome);
         if ("true".equals(verbose)) {
             args.add("-v");
         }


### PR DESCRIPTION
Invoke external tools as SPI services. And modify the analysis output report according to external tool results.
External tool should implement `org.eclipse.emt4j.analysis.report.external
.Tool` for adding records only tools, or extends `org.eclipse.emt4j.analysis.report.external.ModifyReportTool` for modifying(both adding and deleting) records tools.
A `META-INF/services/org.eclipse.emt4j.analysis.report.external
.Tool` configuration file is also required.