### PR TITLE
fix: upgraded Lombok so project can be build on Java 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
             <dependency>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>
-                <version>1.18.8</version>
+                <version>1.18.24</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.velocity</groupId>


### PR DESCRIPTION
Currently building the project on JDK 17 gives the following error:

`[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile (default-compile) on project emt4j-maven-plugin: Fatal error compiling: java.lang.IllegalAccessError: class lombok.javac.apt.LombokProcessor (in unnamed module @0x7ec9d826) cannot access class com.sun.tools.javac.processing.JavacProcessingEnvironment (in module jdk.compiler) because module jdk.compiler does not export com.sun.tools.javac.processing to unnamed module @0x7ec9d826 -> [Help 1]`

Upgrading Lombok to a newer version, for instance 1.18.24 the latest version resolves the issue.