### PR TITLE
fix: should use getQName when reading rule attributes

### DIFF
--- a/emt4j-common/src/main/java/org/eclipse/emt4j/common/rule/ConfRuleRepository.java
+++ b/emt4j-common/src/main/java/org/eclipse/emt4j/common/rule/ConfRuleRepository.java
@@ -127,7 +127,7 @@ public class ConfRuleRepository {
                 confRuleItem.setPriority(attributes.getValue("priority"));
                 List<String[]> userDefineAttrs = new ArrayList<>(attributes.getLength());
                 for (int i = 0; i < attributes.getLength(); i++) {
-                    String attrName = attributes.getLocalName(i);
+                    String attrName = attributes.getQName(i);
                     if (!isFixedAttribute(attrName)) {
                         userDefineAttrs.add(new String[]{attrName, attributes.getValue(i)});
                     }


### PR DESCRIPTION
[Solve issue 49](https://github.com/adoptium/emt4j/issues/49)